### PR TITLE
upgrade solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Visual studio 2022
+.vs
+
 # JetBrains IDE
 .idea/
 

--- a/src/Demos/Gui/.config/dotnet-tools.json
+++ b/src/Demos/Gui/.config/dotnet-tools.json
@@ -3,9 +3,33 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.0.1375-develop",
+      "version": "3.8.1.303",
       "commands": [
         "mgcb"
+      ]
+    },
+    "dotnet-mgcb-editor": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor"
+      ]
+    },
+    "dotnet-mgcb-editor-linux": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-linux"
+      ]
+    },
+    "dotnet-mgcb-editor-windows": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-windows"
+      ]
+    },
+    "dotnet-mgcb-editor-mac": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-mac"
       ]
     }
   }

--- a/src/Demos/Gui/Content/Content.mgcb
+++ b/src/Demos/Gui/Content/Content.mgcb
@@ -10,7 +10,7 @@
 
 #-------------------------------- References --------------------------------#
 
-/reference:..\..\..\..\.nuget\packages\monogame.extended.content.pipeline\3.8.0\tools\MonoGame.Extended.Content.Pipeline.dll
+/reference:..\..\..\..\.nuget\packages\monogame.extended.content.pipeline\3.9.0-prerelease.4\tools\MonoGame.Extended.Content.Pipeline.dll
 
 #---------------------------------- Content ---------------------------------#
 

--- a/src/Demos/Gui/Gui.csproj
+++ b/src/Demos/Gui/Gui.csproj
@@ -19,10 +19,10 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
     <PackageReference Include="MonoGame.Extended" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Gui" Version="3.8" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
   </ItemGroup>
 </Project>

--- a/src/Demos/Gui/Gui.csproj
+++ b/src/Demos/Gui/Gui.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
     <PublishReadyToRun>false</PublishReadyToRun>

--- a/src/Demos/Gui/Gui.csproj
+++ b/src/Demos/Gui/Gui.csproj
@@ -20,9 +20,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
-    <PackageReference Include="MonoGame.Extended" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Gui" Version="3.8" />
+    <PackageReference Include="MonoGame.Extended" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Gui" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
   </ItemGroup>
 </Project>

--- a/src/Demos/Sandbox/.config/dotnet-tools.json
+++ b/src/Demos/Sandbox/.config/dotnet-tools.json
@@ -3,9 +3,33 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.0.1375-develop",
+      "version": "3.8.1.303",
       "commands": [
         "mgcb"
+      ]
+    },
+    "dotnet-mgcb-editor": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor"
+      ]
+    },
+    "dotnet-mgcb-editor-linux": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-linux"
+      ]
+    },
+    "dotnet-mgcb-editor-windows": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-windows"
+      ]
+    },
+    "dotnet-mgcb-editor-mac": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-mac"
       ]
     }
   }

--- a/src/Demos/Sandbox/Content/Content.mgcb
+++ b/src/Demos/Sandbox/Content/Content.mgcb
@@ -10,7 +10,7 @@
 
 #-------------------------------- References --------------------------------#
 
-/reference:..\..\..\..\.nuget\packages\monogame.extended.content.pipeline\3.8.0\tools\MonoGame.Extended.Content.Pipeline.dll
+/reference:..\..\..\..\.nuget\packages\monogame.extended.content.pipeline\3.9.0-prerelease.4\tools\MonoGame.Extended.Content.Pipeline.dll
 
 #---------------------------------- Content ---------------------------------#
 

--- a/src/Demos/Sandbox/Sandbox.csproj
+++ b/src/Demos/Sandbox/Sandbox.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
-    <PackageReference Include="MonoGame.Extended" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Entities" Version="3.8" />
+    <PackageReference Include="MonoGame.Extended" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Entities" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
   </ItemGroup>
 </Project>

--- a/src/Demos/Sandbox/Sandbox.csproj
+++ b/src/Demos/Sandbox/Sandbox.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
     <PublishReadyToRun>false</PublishReadyToRun>

--- a/src/Demos/Sandbox/Sandbox.csproj
+++ b/src/Demos/Sandbox/Sandbox.csproj
@@ -11,10 +11,10 @@
     <MonoGameContentReference Include="**\*.mgcb" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
     <PackageReference Include="MonoGame.Extended" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Entities" Version="3.8" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
   </ItemGroup>
 </Project>

--- a/src/Demos/Tutorials/.config/dotnet-tools.json
+++ b/src/Demos/Tutorials/.config/dotnet-tools.json
@@ -3,9 +3,33 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.0.1375-develop",
+      "version": "3.8.1.303",
       "commands": [
         "mgcb"
+      ]
+    },
+    "dotnet-mgcb-editor": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor"
+      ]
+    },
+    "dotnet-mgcb-editor-linux": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-linux"
+      ]
+    },
+    "dotnet-mgcb-editor-windows": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-windows"
+      ]
+    },
+    "dotnet-mgcb-editor-mac": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-mac"
       ]
     }
   }

--- a/src/Demos/Tutorials/Content/Content.mgcb
+++ b/src/Demos/Tutorials/Content/Content.mgcb
@@ -10,7 +10,7 @@
 
 #-------------------------------- References --------------------------------#
 
-/reference:..\..\..\..\.nuget\packages\monogame.extended.content.pipeline\3.8.0\tools\MonoGame.Extended.Content.Pipeline.dll
+/reference:..\..\..\..\.nuget\packages\monogame.extended.content.pipeline\3.9.0-prerelease.4\tools\MonoGame.Extended.Content.Pipeline.dll
 
 #---------------------------------- Content ---------------------------------#
 

--- a/src/Demos/Tutorials/Tutorials.csproj
+++ b/src/Demos/Tutorials/Tutorials.csproj
@@ -34,12 +34,12 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="5.2.0" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
-    <PackageReference Include="MonoGame.Extended" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Collisions" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Gui" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Particles" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.SceneGraphs" Version="3.8" />
+    <PackageReference Include="MonoGame.Extended" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Collisions" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Gui" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Particles" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.SceneGraphs" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/src/Demos/Tutorials/Tutorials.csproj
+++ b/src/Demos/Tutorials/Tutorials.csproj
@@ -39,7 +39,6 @@
     <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Extended.Gui" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Extended.Particles" Version="3.9.0-prerelease.4" />
-    <PackageReference Include="MonoGame.Extended.SceneGraphs" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
   </ItemGroup>
 </Project>

--- a/src/Demos/Tutorials/Tutorials.csproj
+++ b/src/Demos/Tutorials/Tutorials.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
     <StartupObject />
     <PublishReadyToRun>false</PublishReadyToRun>

--- a/src/Demos/Tutorials/Tutorials.csproj
+++ b/src/Demos/Tutorials/Tutorials.csproj
@@ -41,6 +41,6 @@
     <PackageReference Include="MonoGame.Extended.Particles" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.SceneGraphs" Version="3.8" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/src/Demos/Tutorials/Tutorials.csproj
+++ b/src/Demos/Tutorials/Tutorials.csproj
@@ -41,6 +41,5 @@
     <PackageReference Include="MonoGame.Extended.Particles" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Extended.SceneGraphs" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/src/Demos/Tutorials/Tutorials.csproj
+++ b/src/Demos/Tutorials/Tutorials.csproj
@@ -33,14 +33,14 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="5.2.0" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
     <PackageReference Include="MonoGame.Extended" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Collisions" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Gui" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Particles" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.SceneGraphs" Version="3.8" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/src/Demos/Tweening/.config/dotnet-tools.json
+++ b/src/Demos/Tweening/.config/dotnet-tools.json
@@ -3,9 +3,33 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.0.1375-develop",
+      "version": "3.8.1.303",
       "commands": [
         "mgcb"
+      ]
+    },
+    "dotnet-mgcb-editor": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor"
+      ]
+    },
+    "dotnet-mgcb-editor-linux": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-linux"
+      ]
+    },
+    "dotnet-mgcb-editor-windows": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-windows"
+      ]
+    },
+    "dotnet-mgcb-editor-mac": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-mac"
       ]
     }
   }

--- a/src/Demos/Tweening/Content/Content.mgcb
+++ b/src/Demos/Tweening/Content/Content.mgcb
@@ -10,7 +10,7 @@
 
 #-------------------------------- References --------------------------------#
 
-/reference:..\..\..\..\.nuget\packages\monogame.extended.content.pipeline\3.8.0\tools\MonoGame.Extended.Content.Pipeline.dll
+/reference:..\..\..\..\.nuget\packages\monogame.extended.content.pipeline\3.9.0-prerelease.4\tools\MonoGame.Extended.Content.Pipeline.dll
 
 #---------------------------------- Content ---------------------------------#
 

--- a/src/Demos/Tweening/Tweening.csproj
+++ b/src/Demos/Tweening/Tweening.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
     <PublishReadyToRun>false</PublishReadyToRun>

--- a/src/Demos/Tweening/Tweening.csproj
+++ b/src/Demos/Tweening/Tweening.csproj
@@ -12,10 +12,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
-    <PackageReference Include="MonoGame.Extended" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Input" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Tweening" Version="3.8" />
+    <PackageReference Include="MonoGame.Extended" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Input" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Tweening" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
   </ItemGroup>
 </Project>

--- a/src/Demos/Tweening/Tweening.csproj
+++ b/src/Demos/Tweening/Tweening.csproj
@@ -11,11 +11,11 @@
     <MonoGameContentReference Include="**\*.mgcb" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
     <PackageReference Include="MonoGame.Extended" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Input" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Tweening" Version="3.8" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
   </ItemGroup>
 </Project>

--- a/src/Games/Platformer/.config/dotnet-tools.json
+++ b/src/Games/Platformer/.config/dotnet-tools.json
@@ -3,9 +3,33 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.0.1375-develop",
+      "version": "3.8.1.303",
       "commands": [
         "mgcb"
+      ]
+    },
+    "dotnet-mgcb-editor": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor"
+      ]
+    },
+    "dotnet-mgcb-editor-linux": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-linux"
+      ]
+    },
+    "dotnet-mgcb-editor-windows": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-windows"
+      ]
+    },
+    "dotnet-mgcb-editor-mac": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-mac"
       ]
     }
   }

--- a/src/Games/Platformer/Content/Content.mgcb
+++ b/src/Games/Platformer/Content/Content.mgcb
@@ -10,7 +10,7 @@
 
 #-------------------------------- References --------------------------------#
 
-/reference:..\..\..\..\.nuget\packages\monogame.extended.content.pipeline\3.8.0\tools\MonoGame.Extended.Content.Pipeline.dll
+/reference:..\..\..\..\.nuget\packages\monogame.extended.content.pipeline\3.9.0-prerelease.4\tools\MonoGame.Extended.Content.Pipeline.dll
 
 #---------------------------------- Content ---------------------------------#
 

--- a/src/Games/Platformer/Platformer.csproj
+++ b/src/Games/Platformer/Platformer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
     <PublishReadyToRun>false</PublishReadyToRun>

--- a/src/Games/Platformer/Platformer.csproj
+++ b/src/Games/Platformer/Platformer.csproj
@@ -18,6 +18,5 @@
     <PackageReference Include="MonoGame.Extended.Entities" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Extended.Input" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/src/Games/Platformer/Platformer.csproj
+++ b/src/Games/Platformer/Platformer.csproj
@@ -13,10 +13,10 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="5.2.0" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
-    <PackageReference Include="MonoGame.Extended" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Entities" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Input" Version="3.8" />
+    <PackageReference Include="MonoGame.Extended" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Entities" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Input" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/src/Games/Platformer/Platformer.csproj
+++ b/src/Games/Platformer/Platformer.csproj
@@ -12,12 +12,12 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="5.2.0" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
     <PackageReference Include="MonoGame.Extended" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Entities" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Input" Version="3.8" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/src/Games/Platformer/Platformer.csproj
+++ b/src/Games/Platformer/Platformer.csproj
@@ -18,6 +18,6 @@
     <PackageReference Include="MonoGame.Extended.Entities" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Input" Version="3.8" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>

--- a/src/Games/Pong/.config/dotnet-tools.json
+++ b/src/Games/Pong/.config/dotnet-tools.json
@@ -3,9 +3,33 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.0.1375-develop",
+      "version": "3.8.1.303",
       "commands": [
         "mgcb"
+      ]
+    },
+    "dotnet-mgcb-editor": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor"
+      ]
+    },
+    "dotnet-mgcb-editor-linux": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-linux"
+      ]
+    },
+    "dotnet-mgcb-editor-windows": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-windows"
+      ]
+    },
+    "dotnet-mgcb-editor-mac": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-mac"
       ]
     }
   }

--- a/src/Games/Pong/Content/Content.mgcb
+++ b/src/Games/Pong/Content/Content.mgcb
@@ -10,7 +10,7 @@
 
 #-------------------------------- References --------------------------------#
 
-/reference:..\..\..\..\.nuget\packages\monogame.extended.content.pipeline\3.8.0\tools\MonoGame.Extended.Content.Pipeline.dll
+/reference:..\..\..\..\.nuget\packages\monogame.extended.content.pipeline\3.9.0-prerelease.4\tools\MonoGame.Extended.Content.Pipeline.dll
 
 #---------------------------------- Content ---------------------------------#
 

--- a/src/Games/Pong/Pong.csproj
+++ b/src/Games/Pong/Pong.csproj
@@ -12,10 +12,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
-    <PackageReference Include="MonoGame.Extended" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Gui" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Tweening" Version="3.8" />
+    <PackageReference Include="MonoGame.Extended" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Gui" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Tweening" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
   </ItemGroup>
 </Project>

--- a/src/Games/Pong/Pong.csproj
+++ b/src/Games/Pong/Pong.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
     <PublishReadyToRun>false</PublishReadyToRun>

--- a/src/Games/Pong/Pong.csproj
+++ b/src/Games/Pong/Pong.csproj
@@ -11,11 +11,11 @@
     <MonoGameContentReference Include="**\*.mgcb" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
     <PackageReference Include="MonoGame.Extended" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Gui" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Tweening" Version="3.8" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
   </ItemGroup>
 </Project>

--- a/src/Games/SpaceGame/.config/dotnet-tools.json
+++ b/src/Games/SpaceGame/.config/dotnet-tools.json
@@ -3,9 +3,33 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.0.1375-develop",
+      "version": "3.8.1.303",
       "commands": [
         "mgcb"
+      ]
+    },
+    "dotnet-mgcb-editor": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor"
+      ]
+    },
+    "dotnet-mgcb-editor-linux": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-linux"
+      ]
+    },
+    "dotnet-mgcb-editor-windows": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-windows"
+      ]
+    },
+    "dotnet-mgcb-editor-mac": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-mac"
       ]
     }
   }

--- a/src/Games/SpaceGame/Content/Content.mgcb
+++ b/src/Games/SpaceGame/Content/Content.mgcb
@@ -10,7 +10,7 @@
 
 #-------------------------------- References --------------------------------#
 
-/reference:..\..\..\..\.nuget\packages\monogame.extended.content.pipeline\3.8.0\tools\MonoGame.Extended.Content.Pipeline.dll
+/reference:..\..\..\..\.nuget\packages\monogame.extended.content.pipeline\3.9.0-prerelease.4\tools\MonoGame.Extended.Content.Pipeline.dll
 
 #---------------------------------- Content ---------------------------------#
 

--- a/src/Games/SpaceGame/SpaceGame.csproj
+++ b/src/Games/SpaceGame/SpaceGame.csproj
@@ -13,8 +13,8 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="5.2.0" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
-    <PackageReference Include="MonoGame.Extended" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8" />
+    <PackageReference Include="MonoGame.Extended" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/src/Games/SpaceGame/SpaceGame.csproj
+++ b/src/Games/SpaceGame/SpaceGame.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="MonoGame.Extended" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/Games/SpaceGame/SpaceGame.csproj
+++ b/src/Games/SpaceGame/SpaceGame.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="MonoGame.Extended" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/Games/SpaceGame/SpaceGame.csproj
+++ b/src/Games/SpaceGame/SpaceGame.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
     <StartupObject />
     <PublishReadyToRun>false</PublishReadyToRun>

--- a/src/Games/SpaceGame/SpaceGame.csproj
+++ b/src/Games/SpaceGame/SpaceGame.csproj
@@ -12,10 +12,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="5.2.0" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
     <PackageReference Include="MonoGame.Extended" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Games/StarWarrior/.config/dotnet-tools.json
+++ b/src/Games/StarWarrior/.config/dotnet-tools.json
@@ -3,9 +3,33 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.0.1375-develop",
+      "version": "3.8.1.303",
       "commands": [
         "mgcb"
+      ]
+    },
+    "dotnet-mgcb-editor": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor"
+      ]
+    },
+    "dotnet-mgcb-editor-linux": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-linux"
+      ]
+    },
+    "dotnet-mgcb-editor-windows": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-windows"
+      ]
+    },
+    "dotnet-mgcb-editor-mac": {
+      "version": "3.8.1.303",
+      "commands": [
+        "mgcb-editor-mac"
       ]
     }
   }

--- a/src/Games/StarWarrior/Content/Content.mgcb
+++ b/src/Games/StarWarrior/Content/Content.mgcb
@@ -10,7 +10,7 @@
 
 #-------------------------------- References --------------------------------#
 
-/reference:..\..\..\..\.nuget\packages\monogame.extended.content.pipeline\3.8.0\tools\MonoGame.Extended.Content.Pipeline.dll
+/reference:..\..\..\..\.nuget\packages\monogame.extended.content.pipeline\3.9.0-prerelease.4\tools\MonoGame.Extended.Content.Pipeline.dll
 
 #---------------------------------- Content ---------------------------------#
 

--- a/src/Games/StarWarrior/StarWarrior.csproj
+++ b/src/Games/StarWarrior/StarWarrior.csproj
@@ -20,7 +20,6 @@
     <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Extended.Entities" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/Games/StarWarrior/StarWarrior.csproj
+++ b/src/Games/StarWarrior/StarWarrior.csproj
@@ -15,11 +15,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Autofac" Version="5.2.0" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
     <PackageReference Include="MonoGame.Extended" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Entities" Version="3.8" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Games/StarWarrior/StarWarrior.csproj
+++ b/src/Games/StarWarrior/StarWarrior.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8" />
     <PackageReference Include="MonoGame.Extended.Entities" Version="3.8" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/Games/StarWarrior/StarWarrior.csproj
+++ b/src/Games/StarWarrior/StarWarrior.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon>Icon.ico</ApplicationIcon>
     <StartupObject />
     <PublishReadyToRun>false</PublishReadyToRun>

--- a/src/Games/StarWarrior/StarWarrior.csproj
+++ b/src/Games/StarWarrior/StarWarrior.csproj
@@ -16,9 +16,9 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="5.2.0" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
-    <PackageReference Include="MonoGame.Extended" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.8" />
-    <PackageReference Include="MonoGame.Extended.Entities" Version="3.8" />
+    <PackageReference Include="MonoGame.Extended" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="3.9.0-prerelease.4" />
+    <PackageReference Include="MonoGame.Extended.Entities" Version="3.9.0-prerelease.4" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/src/MonoGame.Extended-samples.sln
+++ b/src/MonoGame.Extended-samples.sln
@@ -1,5 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Games", "Games", "{67A0A50C-1951-4263-AF12-4613C4359044}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Platformer", "Games\Platformer\Platformer.csproj", "{2471554C-453A-47F4-90FF-89B7DEF3636E}"

--- a/src/MonoGame.Extended-samples.sln
+++ b/src/MonoGame.Extended-samples.sln
@@ -2,23 +2,23 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Games", "Games", "{67A0A50C-1951-4263-AF12-4613C4359044}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Platformer", "Games\Platformer\Platformer.csproj", "{2471554C-453A-47F4-90FF-89B7DEF3636E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Platformer", "Games\Platformer\Platformer.csproj", "{2471554C-453A-47F4-90FF-89B7DEF3636E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pong", "Games\Pong\Pong.csproj", "{E9ECBE7B-4B5D-4C94-A220-A669F7EEAFD9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pong", "Games\Pong\Pong.csproj", "{E9ECBE7B-4B5D-4C94-A220-A669F7EEAFD9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpaceGame", "Games\SpaceGame\SpaceGame.csproj", "{5D96ED3F-DF84-4549-A89E-442124888732}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SpaceGame", "Games\SpaceGame\SpaceGame.csproj", "{5D96ED3F-DF84-4549-A89E-442124888732}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "StarWarrior", "Games\StarWarrior\StarWarrior.csproj", "{0E476B69-EC71-47C6-968A-62D718954501}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StarWarrior", "Games\StarWarrior\StarWarrior.csproj", "{0E476B69-EC71-47C6-968A-62D718954501}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Demos", "Demos", "{BAE03398-15B6-44F5-BC73-4E9ECD5AA620}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gui", "Demos\Gui\Gui.csproj", "{3C0DEBEA-DA3E-4F6B-86D9-7A9AC5875AD2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gui", "Demos\Gui\Gui.csproj", "{3C0DEBEA-DA3E-4F6B-86D9-7A9AC5875AD2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sandbox", "Demos\Sandbox\Sandbox.csproj", "{51A3FB82-FDAE-4A34-9006-C8C98274F8D1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sandbox", "Demos\Sandbox\Sandbox.csproj", "{51A3FB82-FDAE-4A34-9006-C8C98274F8D1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tutorials", "Demos\Tutorials\Tutorials.csproj", "{CEE6B044-D293-425B-946A-D814C603624B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tutorials", "Demos\Tutorials\Tutorials.csproj", "{CEE6B044-D293-425B-946A-D814C603624B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tweening", "Demos\Tweening\Tweening.csproj", "{E1C716CE-C0C7-4105-8E98-E62BA8D9489B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tweening", "Demos\Tweening\Tweening.csproj", "{E1C716CE-C0C7-4105-8E98-E62BA8D9489B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -5,6 +5,5 @@
     </config>
     <packageSources>
         <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-        <add key="lithiumtoast" value="https://www.myget.org/F/lithiumtoast/api/v3/index.json" />
     </packageSources>
 </configuration>


### PR DESCRIPTION
 - upgrading solution to VS2022
 - upgrading projects to net6
 - upgrade MG to 3.8.1
the pipeline fails with either 3.8.0 or 3.8.1
 - upgrade MG.Ext to 3.9.0-prerelease.4
 - remove Newtonsoft.Json package
MG.Ext 3.9 doesn't use Newtonsoft and neither the samples
 - remove SceneGraphs package from Tutorials 
SceneGraphs was droped in MG.Ext 3.9

Issues
 - Pong will not pass the first screen. 
Did something changed in Keyboard input?
 - Tutorials does not build because of SceneGraphs
https://github.com/craftworkgames/MonoGame.Extended/issues/305