### PR TITLE
Update doc samples to current versions

### DIFF
--- a/src/DocumentationSamples/2DAnimation/AnimatedSpriteSample/.config/dotnet-tools.json
+++ b/src/DocumentationSamples/2DAnimation/AnimatedSpriteSample/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/DocumentationSamples/2DAnimation/AnimatedSpriteSample/AnimatedSpriteSample.csproj
+++ b/src/DocumentationSamples/2DAnimation/AnimatedSpriteSample/AnimatedSpriteSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <RollForward>Major</RollForward>
         <PublishReadyToRun>false</PublishReadyToRun>
         <TieredCompilation>false</TieredCompilation>
@@ -19,9 +19,9 @@
         <EmbeddedResource Include="Icon.bmp" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Extended" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
     </ItemGroup>
     <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
         <Message Text="Restoring dotnet tools" Importance="High" />

--- a/src/DocumentationSamples/2DAnimation/SpriteSheetSample/.config/dotnet-tools.json
+++ b/src/DocumentationSamples/2DAnimation/SpriteSheetSample/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/DocumentationSamples/2DAnimation/SpriteSheetSample/SpriteSheetSample.csproj
+++ b/src/DocumentationSamples/2DAnimation/SpriteSheetSample/SpriteSheetSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <RollForward>Major</RollForward>
         <PublishReadyToRun>false</PublishReadyToRun>
         <TieredCompilation>false</TieredCompilation>
@@ -19,9 +19,9 @@
         <EmbeddedResource Include="Icon.bmp" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Extended" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
     </ItemGroup>
     <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
         <Message Text="Restoring dotnet tools" Importance="High" />

--- a/src/DocumentationSamples/Camera/OrthographicCamera/camera/.config/dotnet-tools.json
+++ b/src/DocumentationSamples/Camera/OrthographicCamera/camera/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/DocumentationSamples/Camera/OrthographicCamera/camera/camera.csproj
+++ b/src/DocumentationSamples/Camera/OrthographicCamera/camera/camera.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RollForward>Major</RollForward>
     <PublishReadyToRun>false</PublishReadyToRun>
     <TieredCompilation>false</TieredCompilation>
@@ -22,10 +22,10 @@
     <EmbeddedResource Include="Icon.bmp" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Extended" Version="4.0.0" />
-    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.0" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
+    <PackageReference Include="MonoGame.Extended" Version="4.0.2" />
+    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.2" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
     <Message Text="Restoring dotnet tools" Importance="High" />

--- a/src/DocumentationSamples/Collections/Collections/.config/dotnet-tools.json
+++ b/src/DocumentationSamples/Collections/Collections/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/DocumentationSamples/Collections/Collections/Collections.csproj
+++ b/src/DocumentationSamples/Collections/Collections/Collections.csproj
@@ -19,7 +19,7 @@
     <EmbeddedResource Include="Icon.bmp" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Extended" Version="4.0.1" />
+    <PackageReference Include="MonoGame.Extended" Version="4.0.2" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
     <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
   </ItemGroup>

--- a/src/DocumentationSamples/TextureHandling/SpriteSample/.config/dotnet-tools.json
+++ b/src/DocumentationSamples/TextureHandling/SpriteSample/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/DocumentationSamples/TextureHandling/SpriteSample/SpriteSample.csproj
+++ b/src/DocumentationSamples/TextureHandling/SpriteSample/SpriteSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <RollForward>Major</RollForward>
         <PublishReadyToRun>false</PublishReadyToRun>
         <TieredCompilation>false</TieredCompilation>
@@ -19,9 +19,9 @@
         <EmbeddedResource Include="Icon.bmp" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Extended" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
     </ItemGroup>
     <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
         <Message Text="Restoring dotnet tools" Importance="High" />

--- a/src/DocumentationSamples/TextureHandling/Texture2DAtlasSample/.config/dotnet-tools.json
+++ b/src/DocumentationSamples/TextureHandling/Texture2DAtlasSample/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/DocumentationSamples/TextureHandling/Texture2DAtlasSample/Texture2DAtlasSample.csproj
+++ b/src/DocumentationSamples/TextureHandling/Texture2DAtlasSample/Texture2DAtlasSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <RollForward>Major</RollForward>
         <PublishReadyToRun>false</PublishReadyToRun>
         <TieredCompilation>false</TieredCompilation>
@@ -19,9 +19,9 @@
         <EmbeddedResource Include="Icon.bmp" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Extended" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
     </ItemGroup>
     <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
         <Message Text="Restoring dotnet tools" Importance="High" />

--- a/src/DocumentationSamples/TextureHandling/Texture2DRegionSample/.config/dotnet-tools.json
+++ b/src/DocumentationSamples/TextureHandling/Texture2DRegionSample/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/DocumentationSamples/TextureHandling/Texture2DRegionSample/Texture2DRegionSample.csproj
+++ b/src/DocumentationSamples/TextureHandling/Texture2DRegionSample/Texture2DRegionSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <RollForward>Major</RollForward>
         <PublishReadyToRun>false</PublishReadyToRun>
         <TieredCompilation>false</TieredCompilation>
@@ -19,9 +19,9 @@
         <EmbeddedResource Include="Icon.bmp" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Extended" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
     </ItemGroup>
     <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
         <Message Text="Restoring dotnet tools" Importance="High" />


### PR DESCRIPTION
I updated each sample to:
- .NET:   net8.0
- MONOGAME:   3.8.2.1105
- EXTENDED:   4.0.2

**I did the following:**
1. Updated each dotnet-tools.json
2. Updated each .csproj
3. `dotnet restore`
4. `dotnet tool restore`

**Tested by:**
1. Opened each solution or project in visual studio 2022
2. Deleted the BIN folder
3. Ran/built the solutions to make sure they all worked still