### PR TITLE
Update demos to current

### DIFF
--- a/src/Demos/README.md
+++ b/src/Demos/README.md
@@ -1,9 +1,109 @@
 # Demos
 
-Each of these demos are setup like the MonoGame 3.6 Cross Platform Desktop Project template.
+These demos *require* MonoGame.
 
-This means you'll *need* to have MonoGame 3.6 installed on your machine because some of the 
-files are expected to be on your machine.
+To run each demo in Visual Studio, open the project file (*.csproj).
 
-To run each demo in Visual Studio right click the project and select 'Set as StartUp Project'
-then run it as usual.
+## Tweening
+
+This tutorial shows off the `MonoGame.Extended.Tweening` functionality.  A tween is a change between 2 values over time, where the movement is defined by a function.  This could be linear, quadratic, or others.  Adding a `Tween` to movement can give a game entity more feeling and liveliness.
+
+## Sandbox
+
+This is an Entity Component System example.  In the example it has "rain" falling.
+
+There are 2 components:
+1. Expiry
+1. Raindrop
+
+There are 4 systems:
+1. ExpirySystem
+1. HudSystem
+1. RainfallSystem
+1. RenderSystem
+
+## Tutorials
+
+This is a set of tutorials using `Monogame.Extended`.
+
+### Tutorials:Animation
+
+This does nothing yet and you will get an error
+
+### Tutorials:Batching
+
+An alternative to the default Monogame SpriteBatch.
+
+### Tutorials:BitmapFonts
+
+Showing how to use the `Monogame.Extended.BitmapFonts` to load custom fonts from PNG and FNT files.
+
+Additionally how to create a Mono-spaced (Equal-spaced) font using a PNG file.
+
+### Tutorials:Camera
+
+Shows how to use `OrthographicCamera` to draw sprites and create parallax scrolling affect.
+
+### Tutorials:Collision
+
+Shows how to use the `Monogame.Extended.Collisions` to create three types of actors.  Stationary, Moveable, and Player controlled.  Also shows interaction with walls.
+
+### Tutorials:InputListener
+
+Basic examples for the Mouse and Keyboard inputs functionality within `Monogame.Extended`.
+
+### Tutorials:Particles
+
+Quick demo showing how to add a particle system with emitter.
+
+### Tutorials:Shapes
+
+Showing how to use the primitive shapes in `Monogame.Extended`
+
+* DrawPoint
+* DrawRectangle
+* DrawSolidRectangle
+* DrawCircle
+* DrawSolidCircle
+* DrawEllipse
+* DrawSolidEllipse
+* DrawSegment
+* DrawPolygon
+* DrawSolidPolygon
+
+### Tutorials:Sprites
+
+Shows off some features like `Texture2DRegion` and`NinePatch`.  
+
+Also shows how to do clipping.
+
+### Tutorials:TiledMaps
+
+Shows how to load tiles from Tiled maps TMX files.  
+
+### Tutorials:ViewportAdapter
+
+Demonstrates the adapters:
+* BoxingViewportAdapter
+* ViewportAdapter
+* DefaultViewportAdapter
+* ScalingViewportAdapter
+
+Shows how they behave for rescaling the screen.
+
+## GUI
+
+**Deprecated**
+```
+The GUI demo is no longer supported and will be removed.  
+Monogame.Extended.Gui has been deprecated.  
+Monogame.Extended is now recommending and using the GUM GUI framework by FlatRedBall.
+```
+
+For using an in-game GUI, see the [Monogame Extended documentation](https://www.monogameextended.net/docs/features/ui/gum/gum-forms/)
+
+Other links:
+* See blog entry [Monogame Chews Gum](https://www.monogameextended.net/blog/monogame-extended-gum/)
+* And the official GUM documentation [here](https://docs.flatredball.com/gum/monogame/setup).
+
+

--- a/src/Demos/Sandbox/.config/dotnet-tools.json
+++ b/src/Demos/Sandbox/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/Demos/Sandbox/Sandbox.csproj
+++ b/src/Demos/Sandbox/Sandbox.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ApplicationIcon />
         <StartupObject />
         <PublishReadyToRun>false</PublishReadyToRun>
@@ -14,9 +14,9 @@
         <MonoGameContentReference Include="**\*.mgcb" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Extended" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
     </ItemGroup>
 </Project>

--- a/src/Demos/Tutorials/.config/dotnet-tools.json
+++ b/src/Demos/Tutorials/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/Demos/Tutorials/Screens/CollisionScreen.cs
+++ b/src/Demos/Tutorials/Screens/CollisionScreen.cs
@@ -7,6 +7,8 @@ using MonoGame.Extended;
 using MonoGame.Extended.Collisions;
 using MonoGame.Extended.Graphics;
 using MonoGame.Extended.Screens;
+using MonoGame.Extended.BitmapFonts;
+using System.Text;
 
 namespace Tutorials.Screens
 {
@@ -18,6 +20,7 @@ namespace Tutorials.Screens
         private Texture2D _spikyBallTexture;
         private Texture2D _blankTexture;
         private DemoBall _controllableBall;
+        private BitmapFont _bitmapFont;
 
         public new GameMain Game => (GameMain)base.Game;
 
@@ -28,6 +31,7 @@ namespace Tutorials.Screens
             _collisionComponent = new CollisionComponent(new RectangleF(-10000, -5000, 20000, 10000));
             _actors = new List<DemoActor>();
 
+            _bitmapFont = Content.Load<BitmapFont>("Fonts/montserrat-32");
 
             _spriteBatch = new SpriteBatch(GraphicsDevice);
             var spikeyBallTexture = Content.Load<Texture2D>("Textures/spike_ball");
@@ -121,6 +125,10 @@ namespace Tutorials.Screens
             {
                 actor.Draw(_spriteBatch);
             }
+            _spriteBatch.End();
+
+            _spriteBatch.Begin(blendState: BlendState.AlphaBlend);
+            _spriteBatch.DrawString(_bitmapFont, "Use W,A,S,D to move.", new Vector2(5, 5), Color.DarkBlue);
             _spriteBatch.End();
         }
     }

--- a/src/Demos/Tutorials/Screens/ParticlesScreen.cs
+++ b/src/Demos/Tutorials/Screens/ParticlesScreen.cs
@@ -66,16 +66,19 @@ namespace Tutorials.Demos
             {
                 Game.LoadScreen(ScreenName.MainMenu);
             }
+            else
+            {
+                _transform.Rotation += deltaTime;
 
-            _transform.Rotation += deltaTime;
+                // After Game.LoadScreen is called, objects are disposed and we don't want to get an error
+                _particleEffect.Update(deltaTime);
 
-            _particleEffect.Update(deltaTime);
+                if (mouseState.LeftButton == ButtonState.Pressed)
+                    _particleEffect.Trigger(new Vector2(p.X, p.Y));
 
-            if (mouseState.LeftButton == ButtonState.Pressed)
-                _particleEffect.Trigger(new Vector2(p.X, p.Y));
-
-            //_particleEffect.Position = new Vector2(400, 240);
-            //_particleEffect.Trigger(new Vector2(400, 240));
+                //_particleEffect.Position = new Vector2(400, 240);
+                //_particleEffect.Trigger(new Vector2(400, 240));
+            }
         }
 
         public override void Draw(GameTime gameTime)

--- a/src/Demos/Tutorials/Tutorials.csproj
+++ b/src/Demos/Tutorials/Tutorials.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ApplicationIcon>Icon.ico</ApplicationIcon>
         <StartupObject />
         <PublishReadyToRun>false</PublishReadyToRun>
@@ -36,11 +36,11 @@
         <Content Include="Content\Gui\button_rectangle_border.png" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Autofac" Version="5.2.0" />
-        <PackageReference Include="Gum.MonoGame" Version="2024.7.1.1" />
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
+        <PackageReference Include="Autofac" Version="8.1.0" />
+        <PackageReference Include="Gum.MonoGame" Version="2024.9.16.3" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Extended" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
     </ItemGroup>
 </Project>

--- a/src/Demos/Tweening/.config/dotnet-tools.json
+++ b/src/Demos/Tweening/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/Demos/Tweening/Tweening.csproj
+++ b/src/Demos/Tweening/Tweening.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ApplicationIcon />
         <StartupObject />
         <PublishReadyToRun>false</PublishReadyToRun>
@@ -14,9 +14,9 @@
         <MonoGameExtendedPipelineReferencePath>$(MSBuildThisFileDirectory)pipeline-references</MonoGameExtendedPipelineReferencePath>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Extended" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated the existing "Demos" folder items to latest versions of Monogame, Monogame.Extended, GUM, donet, etc.

All projects are now 
* Monogame:   3.8.2.1105
* Extended:   4.0.2
* dotnet:   8.0

### GUI
I was unable to update the GUI project since it was removed in 4.0.0.  I tried updating it but ran into issues where Texture2DAtlas was moved, and since "MonoGame.Extended.Gui 3.9.0-prerelease.3" Skin assumes the Texture2DAtlas is in a different hierarchy, it fails to load.

### Documentation

I updated the readme.md that is included in this folder.