### PR TITLE
Update game demo library versions

### DIFF
--- a/src/Games/Platformer/.config/dotnet-tools.json
+++ b/src/Games/Platformer/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/Games/Platformer/Platformer.csproj
+++ b/src/Games/Platformer/Platformer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ApplicationIcon />
         <StartupObject />
         <PublishReadyToRun>false</PublishReadyToRun>
@@ -15,9 +15,9 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Autofac" Version="5.2.0" />
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Extended" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
     </ItemGroup>
 </Project>

--- a/src/Games/Pong/.config/dotnet-tools.json
+++ b/src/Games/Pong/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/Games/Pong/Pong.csproj
+++ b/src/Games/Pong/Pong.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ApplicationIcon />
         <StartupObject />
         <PublishReadyToRun>false</PublishReadyToRun>
@@ -14,9 +14,9 @@
         <MonoGameContentReference Include="**\*.mgcb" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Extended" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
     </ItemGroup>
 </Project>

--- a/src/Games/SpaceGame/.config/dotnet-tools.json
+++ b/src/Games/SpaceGame/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/Games/SpaceGame/Entities/MeteorFactory.cs
+++ b/src/Games/SpaceGame/Entities/MeteorFactory.cs
@@ -78,7 +78,11 @@ namespace SpaceGame.Entities
             var spawnCircle = new CircleF(playerPosition, 630);
             var spawnAngle = MathHelper.ToRadians(_random.Next(0, 360));
             var spawnPosition = spawnCircle.BoundaryPointAt(spawnAngle);
-            var velocity = (playerPosition - spawnPosition).Rotate(MathHelper.ToRadians(_random.Next(-15, 15))) * _random.Next(3, 10) * 0.01f;
+
+            var velocity = (playerPosition - spawnPosition);
+            velocity.Rotate(MathHelper.ToRadians(_random.Next(-15, 15)));
+            velocity *= _random.Next(3, 10) * 0.01f;
+
             var textureRegion = GetMeteorRegion(4);
             var meteor = new Meteor(textureRegion, spawnPosition, velocity, rotationSpeed, 3);
 

--- a/src/Games/SpaceGame/Entities/Spaceship.cs
+++ b/src/Games/SpaceGame/Entities/Spaceship.cs
@@ -20,7 +20,15 @@ namespace SpaceGame.Entities
 
         public CircleF BoundingCircle;
 
-        public Vector2 Direction => Vector2.UnitX.Rotate(Rotation);
+        public Vector2 Direction
+        {
+            get
+            {
+                Vector2 dir = Vector2.UnitX;
+                dir.Rotate(Rotation);
+                return dir;
+            }
+        }
 
         public Vector2 Position
         {
@@ -91,8 +99,15 @@ namespace SpaceGame.Entities
             }
 
             var angle = Rotation + MathHelper.ToRadians(90);
-            var muzzle1Position = Position + new Vector2(14, 0).Rotate(angle);
-            var muzzle2Position = Position + new Vector2(-14, 0).Rotate(angle);
+
+            Vector2 muzzle1Position = new Vector2(14, 0);
+            muzzle1Position.Rotate(angle);
+            muzzle1Position += Position;
+
+            Vector2 muzzle2Position = new Vector2(-14, 0);
+            muzzle2Position.Rotate(angle);
+            muzzle2Position += Position;
+
             _bulletFactory.Create(muzzle1Position, Direction, angle, 550f);
             _bulletFactory.Create(muzzle2Position, Direction, angle, 550f);
             _fireCooldown = 0.2f;

--- a/src/Games/SpaceGame/SpaceGame.csproj
+++ b/src/Games/SpaceGame/SpaceGame.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ApplicationIcon>Icon.ico</ApplicationIcon>
         <StartupObject />
         <PublishReadyToRun>false</PublishReadyToRun>
@@ -20,10 +20,10 @@
       <None Remove="Properties\**" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Autofac" Version="5.2.0" />
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
+        <PackageReference Include="Autofac" Version="8.1.0" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Extended" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
     </ItemGroup>
 </Project>

--- a/src/Games/StarWarrior/.config/dotnet-tools.json
+++ b/src/Games/StarWarrior/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.303",
+      "version": "3.8.2.1105",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/Games/StarWarrior/StarWarrior.csproj
+++ b/src/Games/StarWarrior/StarWarrior.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ApplicationIcon>Icon.ico</ApplicationIcon>
         <StartupObject />
         <PublishReadyToRun>false</PublishReadyToRun>
@@ -18,10 +18,10 @@
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Autofac" Version="5.2.0" />
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.0" />
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.1.303" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Extended" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.2" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
     </ItemGroup>
     <ItemGroup>
         <Folder Include="Properties\" />


### PR DESCRIPTION
Updated the libraries to use:
Monogame: 3.8.2.1105
Extended: 4.0.2
Dotnet: 8.0

NOTE: I had to fix a few things because of Monogame's Vector2 changes.

NOTE: There is a bug in Extended 4.0.2 with Sprite.Origin and Sprite.OriginNormalized that is causing all sprites to have an incorrect Origin.