### PR TITLE
Update monogame and extended nuget packages

### DIFF
--- a/src/Demos/Gui/.config/dotnet-tools.json
+++ b/src/Demos/Gui/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.1.303",
+      "version": "3.8.3",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.1.303",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.1.303",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.1.303",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.1.303",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/Demos/Sandbox/.config/dotnet-tools.json
+++ b/src/Demos/Sandbox/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/Demos/Sandbox/Sandbox.csproj
+++ b/src/Demos/Sandbox/Sandbox.csproj
@@ -14,9 +14,9 @@
         <MonoGameContentReference Include="**\*.mgcb" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.3" />
+        <PackageReference Include="MonoGame.Extended" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.3" />
     </ItemGroup>
 </Project>

--- a/src/Demos/Tutorials/.config/dotnet-tools.json
+++ b/src/Demos/Tutorials/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/Demos/Tutorials/Screens/CollisionScreen.cs
+++ b/src/Demos/Tutorials/Screens/CollisionScreen.cs
@@ -206,6 +206,7 @@ namespace Tutorials.Screens
         public DemoBall(Sprite sprite) : base(sprite)
         {
             Bounds = new CircleF(Position + Offset, 60);
+            sprite.OriginNormalized = new Vector2(0.5f, 0.5f);
         }
 
         public override void OnCollision(CollisionEventArgs collisionInfo)

--- a/src/Demos/Tutorials/Screens/ParticlesScreen.cs
+++ b/src/Demos/Tutorials/Screens/ParticlesScreen.cs
@@ -39,6 +39,7 @@ namespace Tutorials.Demos
 
             var logoTexture = Content.Load<Texture2D>("Textures/logo-square-128");
             _sprite = new Sprite(logoTexture);
+            _sprite.OriginNormalized = new Vector2(0.5f, 0.5f);
             _transform = new Transform2 { Position = viewportAdapter.Center.ToVector2()};
 
             _particleTexture = new Texture2D(GraphicsDevice, 1, 1);

--- a/src/Demos/Tutorials/Screens/SpritesScreen.cs
+++ b/src/Demos/Tutorials/Screens/SpritesScreen.cs
@@ -36,6 +36,7 @@ namespace Tutorials.Screens
 
             var appleTexture = Content.Load<Texture2D>("Sprites/apple");
             _apple = new Sprite(appleTexture);
+            _apple.OriginNormalized = new Vector2(0.5f, 0.5f);
 
             var axeTexture = Content.Load<Texture2D>("Textures/axe");
             _axeSprite = new Sprite(axeTexture)
@@ -43,22 +44,26 @@ namespace Tutorials.Screens
                 Origin = new Vector2(243, 679),
                 //Position = new Vector2(400, 0),
                 //Scale = Vector2.One * 0.5f
+                OriginNormalized = new Vector2(0.5f, 0.5f)
             };
 
             var spikeyBallTexture = Content.Load<Texture2D>("Textures/spike_ball");
             _spikeyBallSprite = new Sprite(spikeyBallTexture)
             {
                 //Position = new Vector2(400, 340)
+                OriginNormalized = new Vector2(0.5f, 0.5f)
             };
 
             var particleTexture = Content.Load<Texture2D>("Textures/particle");
             _particleSprite0 = new Sprite(particleTexture)
             {
                 //Position = new Vector2(600, 340)
+                OriginNormalized = new Vector2(0.5f, 0.5f)
             };
             _particleSprite1 = new Sprite(particleTexture)
             {
                 //Position = new Vector2(200, 340)
+                OriginNormalized = new Vector2(0.5f, 0.5f)
             };
             _particleOpacity = 0.0f;
         }

--- a/src/Demos/Tutorials/Tutorials.csproj
+++ b/src/Demos/Tutorials/Tutorials.csproj
@@ -36,11 +36,11 @@
         <Content Include="Content\Gui\button_rectangle_border.png" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Autofac" Version="8.1.0" />
-        <PackageReference Include="Gum.MonoGame" Version="2024.9.16.3" />
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+        <PackageReference Include="Autofac" Version="8.3.0" />
+        <PackageReference Include="Gum.MonoGame" Version="2025.5.13.1" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.3" />
+        <PackageReference Include="MonoGame.Extended" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.3" />
     </ItemGroup>
 </Project>

--- a/src/Demos/Tweening/.config/dotnet-tools.json
+++ b/src/Demos/Tweening/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/Demos/Tweening/Tweening.csproj
+++ b/src/Demos/Tweening/Tweening.csproj
@@ -14,9 +14,9 @@
         <MonoGameExtendedPipelineReferencePath>$(MSBuildThisFileDirectory)pipeline-references</MonoGameExtendedPipelineReferencePath>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.3" />
+        <PackageReference Include="MonoGame.Extended" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.3" />
     </ItemGroup>
 </Project>

--- a/src/DocumentationSamples/2DAnimation/AnimatedSpriteSample/.config/dotnet-tools.json
+++ b/src/DocumentationSamples/2DAnimation/AnimatedSpriteSample/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/DocumentationSamples/2DAnimation/AnimatedSpriteSample/AnimatedSpriteSample.csproj
+++ b/src/DocumentationSamples/2DAnimation/AnimatedSpriteSample/AnimatedSpriteSample.csproj
@@ -19,9 +19,9 @@
         <EmbeddedResource Include="Icon.bmp" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.3" />
+        <PackageReference Include="MonoGame.Extended" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.3" />
     </ItemGroup>
     <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
         <Message Text="Restoring dotnet tools" Importance="High" />

--- a/src/DocumentationSamples/2DAnimation/SpriteSheetSample/.config/dotnet-tools.json
+++ b/src/DocumentationSamples/2DAnimation/SpriteSheetSample/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/DocumentationSamples/2DAnimation/SpriteSheetSample/SpriteSheetSample.csproj
+++ b/src/DocumentationSamples/2DAnimation/SpriteSheetSample/SpriteSheetSample.csproj
@@ -19,9 +19,9 @@
         <EmbeddedResource Include="Icon.bmp" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.3" />
+        <PackageReference Include="MonoGame.Extended" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.3" />
     </ItemGroup>
     <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
         <Message Text="Restoring dotnet tools" Importance="High" />

--- a/src/DocumentationSamples/Camera/OrthographicCamera/.config/dotnet-tools.json
+++ b/src/DocumentationSamples/Camera/OrthographicCamera/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/DocumentationSamples/Camera/OrthographicCamera/OrthographicCamera.csproj
+++ b/src/DocumentationSamples/Camera/OrthographicCamera/OrthographicCamera.csproj
@@ -22,10 +22,10 @@
     <EmbeddedResource Include="Icon.bmp" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Extended" Version="4.0.3" />
-    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.3" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Extended" Version="4.1.0" />
+    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.1.0" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.3" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.3" />
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
     <Message Text="Restoring dotnet tools" Importance="High" />

--- a/src/DocumentationSamples/Collections/.config/dotnet-tools.json
+++ b/src/DocumentationSamples/Collections/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/DocumentationSamples/Collections/Collections.csproj
+++ b/src/DocumentationSamples/Collections/Collections.csproj
@@ -19,9 +19,9 @@
     <EmbeddedResource Include="Icon.bmp" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Extended" Version="4.0.3" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Extended" Version="4.1.0" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.3" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.3" />
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
     <Message Text="Restoring dotnet tools" Importance="High" />

--- a/src/DocumentationSamples/Collision/.config/dotnet-tools.json
+++ b/src/DocumentationSamples/Collision/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/DocumentationSamples/Collision/Collision.csproj
+++ b/src/DocumentationSamples/Collision/Collision.csproj
@@ -26,10 +26,10 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Extended" Version="4.0.3" />
-    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.3" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+    <PackageReference Include="MonoGame.Extended" Version="4.1.0" />
+    <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.1.0" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.3" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.3" />
   </ItemGroup>
   <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
     <Message Text="Restoring dotnet tools" Importance="High" />

--- a/src/DocumentationSamples/ContentExtensions/ContentExtensions/.config/dotnet-tools.json
+++ b/src/DocumentationSamples/ContentExtensions/ContentExtensions/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/DocumentationSamples/ContentExtensions/ContentExtensions/ContentExtensions.csproj
+++ b/src/DocumentationSamples/ContentExtensions/ContentExtensions/ContentExtensions.csproj
@@ -23,9 +23,9 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
-    <PackageReference Include="MonoGame.Extended" Version="4.0.3" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.3" />
+    <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.3" />
+    <PackageReference Include="MonoGame.Extended" Version="4.1.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Content\extendedlogo.png">

--- a/src/DocumentationSamples/TextureHandling/SpriteSample/.config/dotnet-tools.json
+++ b/src/DocumentationSamples/TextureHandling/SpriteSample/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/DocumentationSamples/TextureHandling/SpriteSample/SpriteSample.csproj
+++ b/src/DocumentationSamples/TextureHandling/SpriteSample/SpriteSample.csproj
@@ -19,9 +19,9 @@
         <EmbeddedResource Include="Icon.bmp" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.3" />
+        <PackageReference Include="MonoGame.Extended" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.3" />
     </ItemGroup>
     <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
         <Message Text="Restoring dotnet tools" Importance="High" />

--- a/src/DocumentationSamples/TextureHandling/Texture2DAtlasSample/.config/dotnet-tools.json
+++ b/src/DocumentationSamples/TextureHandling/Texture2DAtlasSample/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/DocumentationSamples/TextureHandling/Texture2DAtlasSample/Texture2DAtlasSample.csproj
+++ b/src/DocumentationSamples/TextureHandling/Texture2DAtlasSample/Texture2DAtlasSample.csproj
@@ -19,9 +19,9 @@
         <EmbeddedResource Include="Icon.bmp" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.3" />
+        <PackageReference Include="MonoGame.Extended" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.3" />
     </ItemGroup>
     <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
         <Message Text="Restoring dotnet tools" Importance="High" />

--- a/src/DocumentationSamples/TextureHandling/Texture2DRegionSample/.config/dotnet-tools.json
+++ b/src/DocumentationSamples/TextureHandling/Texture2DRegionSample/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/DocumentationSamples/TextureHandling/Texture2DRegionSample/Texture2DRegionSample.csproj
+++ b/src/DocumentationSamples/TextureHandling/Texture2DRegionSample/Texture2DRegionSample.csproj
@@ -19,9 +19,9 @@
         <EmbeddedResource Include="Icon.bmp" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.3" />
+        <PackageReference Include="MonoGame.Extended" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.3" />
     </ItemGroup>
     <Target Name="RestoreDotnetTools" BeforeTargets="Restore">
         <Message Text="Restoring dotnet tools" Importance="High" />

--- a/src/Games/Platformer/.config/dotnet-tools.json
+++ b/src/Games/Platformer/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/Games/Platformer/EntityFactory.cs
+++ b/src/Games/Platformer/EntityFactory.cs
@@ -92,7 +92,7 @@ namespace Platformer
             var entity = _world.CreateEntity();
             entity.Attach(new Body
             {
-                Position = new Vector2(x * width + width * 0.5f, y * height + height * 0.5f),
+                Position = new Vector2(x * width - width * 0.5f, y * height - height * 0.5f),
                 Size = new Vector2(width, height),
                 BodyType = BodyType.Static
             });

--- a/src/Games/Platformer/Platformer.csproj
+++ b/src/Games/Platformer/Platformer.csproj
@@ -14,10 +14,10 @@
         <MonoGameContentReference Include="**\*.mgcb" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Autofac" Version="5.2.0" />
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+        <PackageReference Include="Autofac" Version="8.3.0" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.3" />
+        <PackageReference Include="MonoGame.Extended" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.3" />
     </ItemGroup>
 </Project>

--- a/src/Games/Pong/.config/dotnet-tools.json
+++ b/src/Games/Pong/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/Games/Pong/Pong.csproj
+++ b/src/Games/Pong/Pong.csproj
@@ -14,9 +14,9 @@
         <MonoGameContentReference Include="**\*.mgcb" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.3" />
+        <PackageReference Include="MonoGame.Extended" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.3" />
     </ItemGroup>
 </Project>

--- a/src/Games/Pong/Screens/PongGameScreen.cs
+++ b/src/Games/Pong/Screens/PongGameScreen.cs
@@ -144,10 +144,10 @@ namespace Pong.Screens
             if (ball.BoundingRectangle.Intersects(paddle.BoundingRectangle))
             {
                 if (ball.BoundingRectangle.Left < paddle.BoundingRectangle.Left)
-                    ball.Position.X = paddle.BoundingRectangle.Left - ball.BoundingRectangle.Width / 2;
+                    ball.Position.X = paddle.BoundingRectangle.Left - ball.BoundingRectangle.Width;
 
                 if (ball.BoundingRectangle.Right > paddle.BoundingRectangle.Right)
-                    ball.Position.X = paddle.BoundingRectangle.Right + ball.BoundingRectangle.Width / 2;
+                    ball.Position.X = paddle.BoundingRectangle.Right;
 
                 ball.Velocity.X = -ball.Velocity.X;
                 return true;
@@ -160,39 +160,41 @@ namespace Pong.Screens
         {
             _ball.Position += _ball.Velocity * elapsedSeconds;
 
-            var halfHeight = _ball.BoundingRectangle.Height / 2;
-            var halfWidth = _ball.BoundingRectangle.Width / 2;
-
             // top and bottom walls
             // TODO: Play 'tink' sound
-            if (_ball.Position.Y - halfHeight < 0)
+            if (_ball.Position.Y < 0)
             {
-                _ball.Position.Y = halfHeight;
+                _ball.Position.Y = 0;
                 _ball.Velocity.Y = -_ball.Velocity.Y;
             }
-
-            if (_ball.Position.Y + halfHeight > ScreenHeight)
+            
+            if (_ball.Position.Y + _ball.BoundingRectangle.Height > ScreenHeight)
             {
-                _ball.Position.Y = ScreenHeight - halfHeight;
+                _ball.Position.Y = ScreenHeight - _ball.BoundingRectangle.Height;
                 _ball.Velocity.Y = -_ball.Velocity.Y;
             }
 
             // left and right is out of bounds 
             // TODO: Play sound and update score
             // TODO: Reset ball to default velocity
-            if (_ball.Position.X > ScreenWidth + halfWidth && _ball.Velocity.X > 0)
+            if (_ball.Position.X > ScreenWidth - _ball.BoundingRectangle.Width && _ball.Velocity.X > 0)
             {
-                _ball.Position = new Vector2(ScreenWidth / 2f, ScreenHeight / 2f);
-                _ball.Velocity = new Vector2(_random.Next(2, 5) * -100, 100);
+                ResetBall(-1);
                 _leftScore++;
             }
 
-            if (_ball.Position.X < -halfWidth && _ball.Velocity.X < 0)
+            if (_ball.Position.X < 0 && _ball.Velocity.X < 0)
             {
-                _ball.Position = new Vector2(ScreenWidth / 2f, ScreenHeight / 2f);
-                _ball.Velocity = new Vector2(_random.Next(2, 5) * 100, 100);
+                ResetBall(1);
                 _rightScore++;
             }
+        }
+
+        private void ResetBall(int xDirection = -1)
+        {
+            _ball.Position = new Vector2(ScreenWidth / 2f + _ball.BoundingRectangle.Width / 2f
+                    , ScreenHeight / 2f + _ball.BoundingRectangle.Height / 2f);
+            _ball.Velocity = new Vector2(_random.Next(2, 5) * 100 * xDirection, 100);
         }
 
         private void ConstrainPaddle(Paddle paddle)
@@ -204,10 +206,10 @@ namespace Pong.Screens
                 paddle.Position.X = ScreenWidth - paddle.BoundingRectangle.Width / 2f;
 
             if (paddle.BoundingRectangle.Top < 0)
-                paddle.Position.Y = paddle.BoundingRectangle.Height / 2f;
+                paddle.Position.Y = 0 ;
 
             if (paddle.BoundingRectangle.Bottom > ScreenHeight)
-                paddle.Position.Y = ScreenHeight - paddle.BoundingRectangle.Height / 2f;
+                paddle.Position.Y = ScreenHeight - paddle.BoundingRectangle.Height ;
         }
 
         private void MovePaddleAi(Paddle paddle, float elapsedSeconds)

--- a/src/Games/SpaceGame/.config/dotnet-tools.json
+++ b/src/Games/SpaceGame/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/Games/SpaceGame/Entities/Laser.cs
+++ b/src/Games/SpaceGame/Entities/Laser.cs
@@ -35,6 +35,7 @@ namespace SpaceGame.Entities
             };
 
             Velocity = velocity;
+            _sprite.OriginNormalized = new Vector2(0.5f, 0.5f);
         }
 
         public override void Update(GameTime gameTime)

--- a/src/Games/SpaceGame/Entities/Meteor.cs
+++ b/src/Games/SpaceGame/Entities/Meteor.cs
@@ -45,6 +45,7 @@ namespace SpaceGame.Entities
             RotationSpeed = rotationSpeed;
             HealthPoints = 1;
             Size = size;
+            _sprite.OriginNormalized = new Vector2(0.5f, 0.5f);
         }
 
         public void Damage(int damage)

--- a/src/Games/SpaceGame/Entities/Spaceship.cs
+++ b/src/Games/SpaceGame/Entities/Spaceship.cs
@@ -58,6 +58,7 @@ namespace SpaceGame.Entities
                 Position = new Vector2(400, 240)
             };
             BoundingCircle = new CircleF(_transform.Position, 20);
+            _sprite.OriginNormalized = new Vector2(0.5f, 0.5f);
         }
 
         public override void Update(GameTime gameTime)

--- a/src/Games/SpaceGame/SpaceGame.csproj
+++ b/src/Games/SpaceGame/SpaceGame.csproj
@@ -20,10 +20,10 @@
       <None Remove="Properties\**" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Autofac" Version="8.1.0" />
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+        <PackageReference Include="Autofac" Version="8.3.0" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.3" />
+        <PackageReference Include="MonoGame.Extended" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.3" />
     </ItemGroup>
 </Project>

--- a/src/Games/StarWarrior/.config/dotnet-tools.json
+++ b/src/Games/StarWarrior/.config/dotnet-tools.json
@@ -3,31 +3,31 @@
   "isRoot": true,
   "tools": {
     "dotnet-mgcb": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb"
       ]
     },
     "dotnet-mgcb-editor": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor"
       ]
     },
     "dotnet-mgcb-editor-linux": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-linux"
       ]
     },
     "dotnet-mgcb-editor-windows": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-windows"
       ]
     },
     "dotnet-mgcb-editor-mac": {
-      "version": "3.8.2.1105",
+      "version": "3.8.3",
       "commands": [
         "mgcb-editor-mac"
       ]

--- a/src/Games/StarWarrior/StarWarrior.csproj
+++ b/src/Games/StarWarrior/StarWarrior.csproj
@@ -17,11 +17,11 @@
         <MonoGameContentReference Include="**\*.mgcb" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Autofac" Version="5.2.0" />
-        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.2.1105" />
-        <PackageReference Include="MonoGame.Extended" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.0.3" />
-        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.2.1105" />
+        <PackageReference Include="Autofac" Version="8.3.0" />
+        <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.3" />
+        <PackageReference Include="MonoGame.Extended" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Extended.Content.Pipeline" Version="4.1.0" />
+        <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.3" />
     </ItemGroup>
     <ItemGroup>
         <Folder Include="Properties\" />


### PR DESCRIPTION
This bumps the version of the samples to 4.1.0, along with Monogame 3.8.3 and latest Gum as well.

I still need to do a pass to re-factor the GUM code now that Vic has done a lot of updates to make GUM easier.